### PR TITLE
Cas clean

### DIFF
--- a/core/Reaction.ml
+++ b/core/Reaction.ml
@@ -26,10 +26,8 @@ let pc  f = { pc_list  = [ f ] ; cas_list = [] ; result = () }
 
 let count_cas r = List.length r.cas_list
 
-let has_cas_on rx r =
-  let id = CAS.id r in
-  (* TODO: optim with a list of ref ids? *)
-  List.exists (fun (CAS.CAS (r, _)) -> CAS.id r = id) rx.cas_list
+(* TODO: optim with a list of ref ids? *)
+let has_cas_on rx r = List.exists (fun cas -> CAS.is_on_ref cas r) rx.cas_list
 
 let try_commit r =
   let success = match r.cas_list with

--- a/extlib/CAS.ml
+++ b/extlib/CAS.ml
@@ -31,20 +31,14 @@ let compare_and_swap r x y =
 
 let ref x = { content = Normal x           ;
               id      = Oo.id (object end) }
-            (* I've been told this is supposed *)
-            (* to be a thread-safe unique id   *)
-
-type refid = int
-
-let id r = r.id
 
 let get r = match r.content with
   | Normal a -> a
   | OnGoingKCAS a -> a
 
-type t =
-  | CAS : 'a ref * 'a updt -> t
+type t = CAS : 'a ref * 'a updt -> t
 
+let is_on_ref (CAS (r1, _)) r2 = r1.id == r2.id
 
 let commit (CAS (r, { expect ; update })) =
   let s = r.content in

--- a/extlib/CAS.ml
+++ b/extlib/CAS.ml
@@ -38,6 +38,8 @@ let get r = match r.content with
 
 type t = CAS : 'a ref * 'a updt -> t
 
+let cas r u = CAS (r, u)
+
 let is_on_ref (CAS (r1, _)) r2 = r1.id == r2.id
 
 let commit (CAS (r, { expect ; update })) =
@@ -87,8 +89,8 @@ end = struct
 
   let (-->) expect update = { expect ; update }
 
-  let (<!=) r u = commit (CAS (r, u))
-  let (<:=) r u = CAS (r, u)
+  let (<:=) = cas
+  let (<!=) r u = commit (cas r u)
 end
 
 open Sugar

--- a/extlib/CAS.mli
+++ b/extlib/CAS.mli
@@ -24,6 +24,8 @@ val get : 'a ref -> 'a
 
 type t
 
+val cas : 'a ref -> 'a updt -> t
+
 val is_on_ref : t -> 'a ref -> bool
 
 val commit : t -> bool

--- a/extlib/CAS.mli
+++ b/extlib/CAS.mli
@@ -18,16 +18,13 @@ type 'a ref
 
 type 'a updt = { expect : 'a ; update : 'a }
 
-type refid
-
 val ref : 'a -> 'a ref
-
-val id : 'a ref -> refid
 
 val get : 'a ref -> 'a
 
-type t =
-  | CAS : 'a ref * 'a updt -> t
+type t
+
+val is_on_ref : t -> 'a ref -> bool
 
 val commit : t -> bool
 


### PR DESCRIPTION
Simple fix to avoid exposing the constructor out of the CAS module.
